### PR TITLE
added missing <body> element

### DIFF
--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -26,6 +26,8 @@
   </nav>
 </header>
 
+<body>
 {{- block "main" . }}{{- end }}
+</body>
 
 </html>


### PR DESCRIPTION
This also fixes LiveReload, per [the docs](https://gohugo.io/getting-started/usage/#livereload):

>Hugo injects the LiveReload <script> before the closing </body> in your templates and will therefore not work if this tag is not present..