### PR TITLE
Add support for Mermaid

### DIFF
--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -16,6 +16,9 @@
 <script defer src="https://cdn.jsdelivr.net/npm/katex@0.10.2/dist/katex.min.js" integrity="sha256-TxnaXkPUeemXTVhlS5tDIVg42AvnNAotNaQjjYKK9bc=" crossorigin="anonymous"></script>
 <script defer src="https://cdn.jsdelivr.net/npm/katex@0.10.2/dist/contrib/mathtex-script-type.min.js" integrity="sha256-b8diVEOgPDxUp0CuYCi7+lb5xIGcgrtIdrvE8d/oztQ=" crossorigin="anonymous"></script>
 {{- end }}
+{{- if .Params.mermaid }}
+<script defer src="https://unpkg.com/mermaid@8.4.0/dist/mermaid.min.js"></script>
+{{ end }}
 
 <header class="{{ if .Site.Params.brightheader }}bright{{ else }}dark{{ end }}">
   <h2><a href="{{ .Site.BaseURL }}">{{ .Site.Title }}</a></h2>

--- a/layouts/shortcodes/mermaid.html
+++ b/layouts/shortcodes/mermaid.html
@@ -1,0 +1,3 @@
+<div class="mermaid">
+  {{ .Inner }}
+</div>


### PR DESCRIPTION
Mermaid is useful for creating diagrams, and it would be nice if this theme bundled it like it does with KaTeX. I also added a shortcode so it could be easily used within templates.

```
{{<mermaid>}}
graph LR;
  A[Hard edge] -->|Link text| B(Round edge)
    B --> C{Decision}
    C -->|One| D[Result one asdf]
    C -->|Two| E[Result two]
{{</mermaid>}}
```

will render

![image](https://user-images.githubusercontent.com/977151/67174330-a1af3d80-f38f-11e9-8736-75ab9aaf82e6.png)
